### PR TITLE
Add inference support for new models

### DIFF
--- a/docs/Inference.md
+++ b/docs/Inference.md
@@ -1,0 +1,33 @@
+# Additional Inference Models
+
+This guide shows how to run inference with **Skywork-R1V**, **EarthDial** and **NVILA** models using the existing scripts.
+
+## Skywork-R1V
+
+Ensure the checkpoint `Skywork/Skywork-R1V-38B` is placed under `PATH_TO_MODEL_FOLDER`.
+
+```bash
+python ./inference/xbd_subset_baseline.py --model_id "Skywork/Skywork-R1V-38B"
+```
+
+## EarthDial
+
+Download the weights from Hugging Face (`akshaydudhane/EarthDial_4B_RGB`) and place them under the model folder. Inference can be launched as follows:
+
+```bash
+python ./inference/xbd_subset_baseline.py --model_id "akshaydudhane/EarthDial_4B_RGB"
+```
+
+## NVILA
+
+NVILA models are loaded via the `llava` backend. Specify the model id `Efficient-Large-Model/NVILA-8B`:
+
+```bash
+python ./inference/xbd_subset_baseline.py --model_id "Efficient-Large-Model/NVILA-8B"
+```
+
+Alternatively, NVILA's official repository provides a CLI:
+
+```bash
+python -m llava.cli.infer --model-path /path/to/NVILA-8B --text "Describe the change" --media pre.png post.png
+```

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -24,6 +24,9 @@ MODEL_LIST = [
     "llava-hf/llava-onevision-qwen2-7b-ov-hf",
     "mistralai/Pixtral-12B-2409",
     "BiliSakura/RSCCM",
+    "Skywork/Skywork-R1V-38B",
+    "akshaydudhane/EarthDial_4B_RGB",
+    "Efficient-Large-Model/NVILA-8B",
 ]
 T5_MODEL_REPO = "sentence-transformers/sentence-t5-xxl"
 BERT_MODEL_REPO = "FacebookAI/roberta-large"

--- a/utils/model_hub.py
+++ b/utils/model_hub.py
@@ -1,3 +1,4 @@
+import math
 from transformers import (
     Qwen2_5_VLForConditionalGeneration,
     Qwen2VLForConditionalGeneration,
@@ -38,6 +39,105 @@ from utils.constants import (
     DEFAULT_DEVICE_MAP,
     MODEL_LIST,
 )
+
+
+def build_transform(input_size: int):
+    IMAGENET_MEAN = (0.485, 0.456, 0.406)
+    IMAGENET_STD = (0.229, 0.224, 0.225)
+    transform = T.Compose(
+        [
+            T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+            T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+            T.ToTensor(),
+            T.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )
+    return transform
+
+
+def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
+    best_ratio_diff = float("inf")
+    best_ratio = (1, 1)
+    area = width * height
+    for ratio in target_ratios:
+        target_aspect_ratio = ratio[0] / ratio[1]
+        ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+        if ratio_diff < best_ratio_diff:
+            best_ratio_diff = ratio_diff
+            best_ratio = ratio
+        elif ratio_diff == best_ratio_diff:
+            if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                best_ratio = ratio
+    return best_ratio
+
+
+def dynamic_preprocess(image, min_num=1, max_num=12, image_size=448, use_thumbnail=False):
+    orig_width, orig_height = image.size
+    aspect_ratio = orig_width / orig_height
+    target_ratios = set(
+        (i, j)
+        for n in range(min_num, max_num + 1)
+        for i in range(1, n + 1)
+        for j in range(1, n + 1)
+        if i * j <= max_num and i * j >= min_num
+    )
+    target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+    target_aspect_ratio = find_closest_aspect_ratio(
+        aspect_ratio, target_ratios, orig_width, orig_height, image_size
+    )
+    target_width = image_size * target_aspect_ratio[0]
+    target_height = image_size * target_aspect_ratio[1]
+    blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
+    resized_img = image.resize((target_width, target_height))
+    processed_images = []
+    for i in range(blocks):
+        box = (
+            (i % (target_width // image_size)) * image_size,
+            (i // (target_width // image_size)) * image_size,
+            ((i % (target_width // image_size)) + 1) * image_size,
+            ((i // (target_width // image_size)) + 1) * image_size,
+        )
+        split_img = resized_img.crop(box)
+        processed_images.append(split_img)
+    assert len(processed_images) == blocks
+    if use_thumbnail and len(processed_images) != 1:
+        thumbnail_img = image.resize((image_size, image_size))
+        processed_images.append(thumbnail_img)
+    return processed_images
+
+
+def load_image(image_file, input_size=448, max_num=12):
+    image = Image.open(image_file).convert("RGB")
+    transform = build_transform(input_size=input_size)
+    images = dynamic_preprocess(image, image_size=input_size, use_thumbnail=True, max_num=max_num)
+    pixel_values = [transform(img) for img in images]
+    pixel_values = torch.stack(pixel_values)
+    return pixel_values
+
+
+def split_model(model_path):
+    device_map = {}
+    world_size = torch.cuda.device_count()
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    num_layers = config.llm_config.num_hidden_layers
+    num_layers_per_gpu = math.ceil(num_layers / (world_size - 0.5))
+    num_layers_per_gpu = [num_layers_per_gpu] * world_size
+    num_layers_per_gpu[0] = math.ceil(num_layers_per_gpu[0] * 0.5)
+    layer_cnt = 0
+    for i, num_layer in enumerate(num_layers_per_gpu):
+        for _ in range(num_layer):
+            device_map[f"language_model.model.layers.{layer_cnt}"] = i
+            layer_cnt += 1
+    device_map["vision_model"] = 0
+    device_map["mlp1"] = 0
+    device_map["language_model.model.tok_embeddings"] = 0
+    device_map["language_model.model.embed_tokens"] = 0
+    device_map["language_model.output"] = 0
+    device_map["language_model.model.norm"] = 0
+    device_map["language_model.model.rotary_emb"] = 0
+    device_map["language_model.lm_head"] = 0
+    device_map[f"language_model.model.layers.{num_layers - 1}"] = 0
+    return device_map
 
 
 def model_loader(
@@ -117,6 +217,43 @@ def model_loader(
             attn_implementation="flash_attention_2",
         ).to(device)
         processor = AutoProcessor.from_pretrained(model_path)
+    elif model_id == "Skywork/Skywork-R1V-38B":
+        device_map = split_model(model_path)
+        model = (
+            AutoModel.from_pretrained(
+                model_path,
+                torch_dtype=torch.bfloat16,
+                load_in_8bit=False,
+                low_cpu_mem_usage=True,
+                use_flash_attn=True,
+                trust_remote_code=True,
+                device_map=device_map,
+            )
+            .eval()
+        )
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, trust_remote_code=True, use_fast=False
+        )
+    elif model_id == "akshaydudhane/EarthDial_4B_RGB":
+        model = (
+            AutoModelForCausalLM.from_pretrained(
+                model_path,
+                low_cpu_mem_usage=True,
+                torch_dtype=torch.bfloat16,
+                device_map=device_map,
+                trust_remote_code=True,
+            )
+            .eval()
+        )
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_path, trust_remote_code=True, use_fast=False
+        )
+        image_processor = build_transform
+    elif model_id == "Efficient-Large-Model/NVILA-8B":
+        import llava
+
+        model = llava.load(model_path)
+        tokenizer = model.tokenizer
     elif model_id == "microsoft/Phi-4-multimodal-instruct":
 
         model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
## Summary
- extend MODEL_LIST with Skywork-R1V, EarthDial and NVILA models
- implement Skywork image loader and device mapping utilities
- add loaders for Skywork, EarthDial and NVILA models
- support these models in baseline inference logic
- document usage in `docs/Inference.md`

## Testing
- `python -m py_compile utils/model_hub.py inference/inference_baseline.py utils/constants.py`

------
https://chatgpt.com/codex/tasks/task_e_684bc5e268ec8320889de700b1471eeb